### PR TITLE
Revert service-parent to version 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.commonjava</groupId>
     <artifactId>service-parent</artifactId>
-    <version>2</version>
+    <version>1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.commonjava.indy.service</groupId>

--- a/src/test/java/org/commonjava/indy/service/archive/ftests/ArchiveGenerateContentTest.java
+++ b/src/test/java/org/commonjava/indy/service/archive/ftests/ArchiveGenerateContentTest.java
@@ -58,6 +58,7 @@ public class ArchiveGenerateContentTest
      */
     @Test
     public void testSuccessGenerateContent()
+            throws InterruptedException
     {
         File file = new File( "data/archive", SUCCESS_BUILD_ARCHIVE );
         assertFalse( file.exists() );
@@ -69,6 +70,9 @@ public class ArchiveGenerateContentTest
                .post( "/api/archive/generate" )
                .then()
                .statusCode( anyOf( is( 202 ), is( 200 ) ) );
+
+        // Wait for the completion of generating process
+        Thread.sleep( 6000 );
 
         assertTrue( file.exists() );
         assertTrue( file.length() > 0L );

--- a/src/test/java/org/commonjava/indy/service/archive/ftests/ArchiveRetrieveContentTest.java
+++ b/src/test/java/org/commonjava/indy/service/archive/ftests/ArchiveRetrieveContentTest.java
@@ -57,6 +57,7 @@ public class ArchiveRetrieveContentTest
 {
     @Test
     public void testRetrieveContent()
+            throws InterruptedException
     {
         File file = new File( "data/archive", SUCCESS_BUILD_ARCHIVE );
         assertFalse( file.exists() );
@@ -68,6 +69,9 @@ public class ArchiveRetrieveContentTest
                .post( "/api/archive/generate" )
                .then()
                .statusCode( anyOf( is( 202 ), is( 200 ) ) );
+
+        // Wait for the completion of generating process
+        Thread.sleep( 6000 );
 
         given().when()
                .get( "/api/archive/" + SUCCESS_BUILD )

--- a/src/test/java/org/commonjava/indy/service/archive/ftests/profile/ArchiveFunctionProfile.java
+++ b/src/test/java/org/commonjava/indy/service/archive/ftests/profile/ArchiveFunctionProfile.java
@@ -23,7 +23,7 @@ import java.util.Map;
 public class ArchiveFunctionProfile
                 implements QuarkusTestProfile
 {
-    public static final String MAIN_INDY = "indy-admin.psi.redhat.com";
+    public static final String MAIN_INDY = "http://indy-admin.psi.redhat.com";
 
     public static final String STORAGE_DIR = "data";
 


### PR DESCRIPTION
In this version, quarkus is 1.12.2.Final that still doesn't support HTTP2, it will not have some restricted client requests limit validations which start from HTTP2.0.